### PR TITLE
:sparkles: Feat: 이벤트 상세페이지 API 연동(지도 제외)

### DIFF
--- a/src/api/eventDetailAPI.js
+++ b/src/api/eventDetailAPI.js
@@ -1,0 +1,5 @@
+import { APIService } from './axios';
+
+export const getEventDetail = async (eventId) => {
+  return APIService.public.get(`/api/events/${eventId}`);
+};

--- a/src/components/eventDetailPage/EventBasicInfo.jsx
+++ b/src/components/eventDetailPage/EventBasicInfo.jsx
@@ -3,63 +3,51 @@ import SectionWrapper from '../global/sectionWrapper/SectionWrapper';
 import styles from './EventBasicInfo.module.css';
 import artweekPoster from '@assets/images/artweek.png';
 
-export default function EventBasicInfo({
-  posterSrc = artweekPoster,
-  title = '2025 인사아트위크',
-  location = '인사동 일대 참여',
-  period = '2025-06-04 ~ 2025-06-14',
-  target = '전체',
-  submitWindow = '-',
-  price = '-',
-  contact = '-',
-  note = '-',
-}) {
+export default function EventBasicInfo({ data }) {
+  const { mainImage, title, location, startDate, endDate, eventTime, recruitTarget, price, inquiry, eventCategory } =
+    data || {};
+
+  const safe = (v) => (v && v !== '' ? v : '-');
+
   return (
     <SectionWrapper>
       <section className={styles.wrap} aria-labelledby='event-basic-title'>
         {/* 포스터 */}
         <div className={styles.posterCard}>
-          {posterSrc ? (
-            <img src={posterSrc} alt={`${title} 포스터`} />
-          ) : (
-            <div className={styles.posterPlaceholder}>포스터</div>
-          )}
+          <img src={safe(mainImage) !== '-' ? mainImage : artweekPoster} alt={`${safe(title)} 포스터`} />
         </div>
 
         {/* 기본 정보 */}
         <div className={styles.info}>
           <h2 id='event-basic-title' className={styles.title}>
-            {title}
+            {safe(title)}
           </h2>
 
           <dl className={styles.meta}>
             <div>
               <dt>장소</dt>
-              <dd>{location}</dd>
+              <dd>{safe(location)}</dd>
             </div>
             <div>
               <dt>기간</dt>
-              <dd>{period}</dd>
+              <dd>
+                {safe(startDate)} ~ {safe(endDate)} {safe(eventTime)}
+              </dd>
             </div>
             <div>
               <dt>모집대상</dt>
-              <dd>{target}</dd>
-            </div>
-            <div>
-              <dt>접수기간</dt>
-              <dd>{submitWindow}</dd>
+              <dd>{safe(recruitTarget)}</dd>
             </div>
             <div>
               <dt>기본가</dt>
-              <dd>{price}</dd>
+              <dd>{safe(price)}</dd>
             </div>
             <div>
               <dt>문의</dt>
-              <dd>{contact}</dd>
+              <dd>{safe(inquiry)}</dd>
             </div>
             <div>
               <dt>비고</dt>
-              <dd>{note}</dd>
             </div>
           </dl>
 

--- a/src/components/eventDetailPage/EventBasicInfo.module.css
+++ b/src/components/eventDetailPage/EventBasicInfo.module.css
@@ -3,7 +3,7 @@
   justify-content: center;
   align-items: center;
   gap: clamp(10rem, 4vw, 8rem);
-  margin: 8rem;
+  margin: 10rem;
 }
 
 .posterCard {
@@ -16,7 +16,7 @@
   align-items: center;
   justify-content: center;
   width: 100%;
-  max-width: 33rem;
+  max-width: 28rem;
 }
 
 .posterCard img {
@@ -35,10 +35,10 @@
 }
 
 .title {
-  font-size: clamp(3rem, 3vw, 2.2rem);
+  font-size: clamp(2.8rem, 3vw, 2rem);
   font-weight: 700;
   letter-spacing: 0.02em;
-  margin: 0.2rem 0 0.5rem;
+  margin: 0.2rem 0 2rem;
   text-align: center;
   color: #000000;
 }

--- a/src/components/eventDetailPage/EventDescription.jsx
+++ b/src/components/eventDetailPage/EventDescription.jsx
@@ -2,43 +2,27 @@
 import SectionWrapper from '../global/sectionWrapper/SectionWrapper';
 import styles from './EventDescription.module.css';
 
-export default function EventDescription() {
-  const dummyData = {
-    title: '2025 인사아트위크',
-    period: '2025년 6월 4일 ~ 6월 14일',
-    location: '인사동 일대 참여 갤러리 자체 기획 전시',
-    description: `
-      2025 인사아트위크(Insa Art Week 2025)는 한국 예술의 중심지인 인사동에서 
-      전통과 현대, 지역성과 세계가 교차하는 복합문화예술축제로, 
-      오는 6월 4일(수)부터 11일간 개최됩니다.
-
-      2023년과 2024년에 이어 ‘예술은 어디에나 있다 – Art takes alive!’라는 주제 아래, 
-      도시 공간은 예술의 무대로 확장되며, 예술의 사회적 역할과 일상 속 감각을 재조명하고자 합니다.
-
-      10곳의 갤러리를 방문해 엽서를 모아오시면
-      추첨을 통해 소정의 상품을 드리는 이벤트도 진행 예정입니다.
-
-      많은 관심과 참여 부탁드립니다!
-
-      상품 받는 곳: 인사동홍보관 (종로구 인사동11길 19)
-    `,
-  };
+export default function EventDescription({ data }) {
+  const title = data?.title || '-';
+  const period = data?.startDate && data?.endDate ? `${data.startDate} ~ ${data.endDate}` : '-';
+  const location = data?.location || '-';
+  const description = data?.description || '상세 설명이 없습니다.';
 
   return (
     <SectionWrapper>
       <section className={styles.wrap}>
-        <h2 className={styles.title}>&lt;{dummyData.title}&gt;</h2>
+        <h2 className={styles.title}>&lt;{title}&gt;</h2>
 
         <div className={styles.meta}>
           <p>
-            <strong>일시:</strong> {dummyData.period}
+            <strong>일시:</strong> {period}
           </p>
           <p>
-            <strong>장소:</strong> {dummyData.location}
+            <strong>장소:</strong> {location}
           </p>
         </div>
 
-        <p className={styles.desc}>{dummyData.description}</p>
+        <p className={styles.desc}>{description}</p>
       </section>
     </SectionWrapper>
   );

--- a/src/components/eventDetailPage/EventVideo.jsx
+++ b/src/components/eventDetailPage/EventVideo.jsx
@@ -2,7 +2,8 @@
 import SectionWrapper from '../global/sectionWrapper/SectionWrapper';
 import styles from './EventVideo.module.css';
 
-export default function EventVideo() {
+export default function EventDescription({ data }) {
+  const caption = data?.title || '-';
   const dummyVideo = {
     title: 'IAW2025',
     caption: '2025 인사아트위크 홍보영상',
@@ -17,7 +18,7 @@ export default function EventVideo() {
             <div className={styles.playButton}>▶</div>
           </div>
         </div>
-        <p className={styles.caption}>{dummyVideo.caption}</p>
+        <p className={styles.caption}>{caption}</p>
       </section>
     </SectionWrapper>
   );

--- a/src/hooks/useEventDetailHook.js
+++ b/src/hooks/useEventDetailHook.js
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react';
+import { getEventDetail } from '@api/eventDetailAPI';
+
+export default function useEventDetail(eventId) {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [data, setData] = useState(null);
+
+  useEffect(() => {
+    let active = true;
+    (async () => {
+      try {
+        const res = await getEventDetail(eventId);
+        if (active) setData(res.data);
+      } catch (err) {
+        if (active) setError(err);
+      } finally {
+        if (active) setLoading(false);
+      }
+    })();
+    return () => {
+      active = false;
+    };
+  }, [eventId]);
+
+  return { loading, error, data };
+}

--- a/src/pages/EventDetailPage.jsx
+++ b/src/pages/EventDetailPage.jsx
@@ -1,12 +1,21 @@
+import { useParams } from 'react-router-dom';
 import { EventBasicInfo, EventDescription, EventVideo, EventMap } from '@components/eventDetailPage';
+import PageLoader from '../components/global/pageLoader/PageLoader';
 import styles from './EventDetailPage.module.css';
+import useEventDetail from '../hooks/useEventDetailHook';
 
 export default function EventDetailPage() {
+  const { id } = useParams();
+  const { loading, error, data } = useEventDetail(id);
+
+  if (loading) return <PageLoader />;
+  if (error) return <div className={styles.page}>이벤트 상세를 불러오지 못했습니다.</div>;
+
   return (
     <div className={styles.page}>
-      <EventBasicInfo />
-      <EventDescription />
-      <EventVideo />
+      <EventBasicInfo data={data} />
+      <EventDescription data={data} />
+      <EventVideo data={data} />
       <EventMap />
     </div>
   );


### PR DESCRIPTION
## ✨ 새로운 기능 / 변경 사항
- 이벤트 상세 API (`GET /api/events/:id`) 연동
- 상세 페이지 섹션 연결: 기본 정보, 상세 소개, 영상

## 🛠 구현 상세

- EventDetailPage에서 useParams()로 id 추출 → 훅 호출 → EventBasicInfo, EventDescription에 data prop 전달

## 📱 테스트 방법

- [x] 브라우저에서 정상 동작 확인


## 🔧 추가 고려사항

## 🔗 관련 문서 / 이슈

- closed #14 