### PR TITLE
:sparkles:Feat: 이벤트 목록 페이지 API 연동

### DIFF
--- a/src/api/eventList.js
+++ b/src/api/eventList.js
@@ -1,0 +1,19 @@
+import { APIService } from './axios';
+
+export const getEventList = async ({ eventCategory, eventPeriod, keyword, pageNum, pageSize }) => {
+  try {
+    const res = await APIService.public.get('/api/events', {
+      params: {
+        eventCategory,
+        eventPeriod,
+        keyword,
+        pageNum,
+        pageSize,
+      },
+    });
+    return res.data;
+  } catch (err) {
+    console.error('이벤트 페이지 조회 실패:', err);
+    throw err;
+  }
+};

--- a/src/components/eventListPage/EventCard.jsx
+++ b/src/components/eventListPage/EventCard.jsx
@@ -1,16 +1,16 @@
 import styles from './EventCard.module.css';
 
 export default function EventCard({ event }) {
-  const { thumbnail, title, startDate, endDate, place } = event;
+  const { mainImage, title, startDate, endDate, location } = event;
 
   return (
     <div className={styles.card}>
-      <img src={thumbnail || ''} alt={title} className={styles.img} />
+      <img src={mainImage} alt={title} className={styles.img} />
       <p className={styles.title}>{title}</p>
       <p className={styles.date}>
         {startDate} ~ {endDate}
       </p>
-      <p className={styles.place}>{place}</p>
+      <p className={styles.place}>{location}</p>
     </div>
   );
 }

--- a/src/components/eventListPage/FilterBar.jsx
+++ b/src/components/eventListPage/FilterBar.jsx
@@ -1,7 +1,7 @@
 import styles from './FilterBar.module.css';
 import { useState } from 'react';
 
-export default function FilterBar() {
+export default function FilterBar({ onFilterChange }) {
   const categories = ['전체', '공연', '전시', '축제', '교육/강좌', '기타'];
   const periods = ['전체', '오늘', '이번주', '이번달'];
 
@@ -10,12 +10,12 @@ export default function FilterBar() {
 
   const handleCategoryClick = (category) => {
     setSelectedCategory(category);
-    console.log('Category filter applied:', category);
+    if (onFilterChange) onFilterChange(category, selectedPeriod);
   };
 
   const handlePeriodClick = (period) => {
     setSelectedPeriod(period);
-    console.log('Period filter applied:', period);
+    if (onFilterChange) onFilterChange(selectedCategory, period);
   };
 
   return (

--- a/src/pages/EventListPage.jsx
+++ b/src/pages/EventListPage.jsx
@@ -1,97 +1,74 @@
 import { EventCard, FilterBar, Pagination } from '@components/eventListPage';
 import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { getEventList } from '@api/eventList';
 import styles from './EventListPage.module.css';
-import poster from '@assets/images/poster.png';
 
 export default function EventListPage() {
   const [events, setEvents] = useState([]);
-  const totalPages = 3;
+  const [totalPages, setTotalPages] = useState(1);
   const [currentPage, setCurrentPage] = useState(1);
+  const pageSize = 8;
   const navigate = useNavigate();
 
+  const [selectedCategory, setSelectedCategory] = useState('ALL');
+  const [selectedPeriod, setSelectedPeriod] = useState('ALL');
+
+  const categoryMap = {
+    전체: 'ALL',
+    공연: 'SHOW',
+    전시: 'EXHIBITION',
+    축제: 'FESTIVAL',
+    '교육/강좌': 'EDUEXP',
+    기타: 'ETC',
+  };
+  const periodMap = {
+    전체: 'ALL',
+    오늘: 'TODAY',
+    이번주: 'THIS_WEEK',
+    이번달: 'THIS_MONTH',
+  };
+
   useEffect(() => {
-    const dummyData = [
-      {
-        id: 1,
-        thumbnail: poster,
-        title: 'AW2025 인사아트위크',
-        startDate: '2025-06-04',
-        endDate: '2025-06-14',
-        place: '인사동 아트센터',
-      },
-      {
-        id: 2,
-        thumbnail: poster,
-        title: 'AW2025 인사아트위크',
-        startDate: '2025-06-04',
-        endDate: '2025-06-14',
-        place: '인사동 아트센터',
-      },
-      {
-        id: 3,
-        thumbnail: poster,
-        title: 'AW2025 인사아트위크',
-        startDate: '2025-06-04',
-        endDate: '2025-06-14',
-        place: '인사동 아트센터',
-      },
-      {
-        id: 4,
-        thumbnail: poster,
-        title: 'AW2025 인사아트위크',
-        startDate: '2025-06-04',
-        endDate: '2025-06-14',
-        place: '인사동 아트센터',
-      },
-      {
-        id: 5,
-        thumbnail: poster,
-        title: 'AW2025 인사아트위크',
-        startDate: '2025-06-04',
-        endDate: '2025-06-14',
-        place: '인사동 아트센터',
-      },
-      {
-        id: 6,
-        thumbnail: poster,
-        title: 'AW2025 인사아트위크',
-        startDate: '2025-06-04',
-        endDate: '2025-06-14',
-        place: '인사동 아트센터',
-      },
-      {
-        id: 7,
-        thumbnail: poster,
-        title: 'AW2025 인사아트위크',
-        startDate: '2025-06-04',
-        endDate: '2025-06-14',
-        place: '인사동 아트센터',
-      },
-      {
-        id: 8,
-        thumbnail: poster,
-        title: 'AW2025 인사아트위크',
-        startDate: '2025-06-04',
-        endDate: '2025-06-14',
-        place: '인사동 아트센터',
-      },
-    ];
-    setEvents(dummyData);
-  }, []);
+    const fetchEvents = async () => {
+      try {
+        const res = await getEventList({
+          eventCategory: selectedCategory,
+          eventPeriod: selectedPeriod,
+          keyword: '',
+          pageNum: currentPage,
+          pageSize: pageSize,
+        });
+        console.log('API 응답:', res);
+        const data = res?.data?.data || res?.data || res || {};
+        setEvents(data.content || []);
+        setTotalPages(data.totalPages || 1);
+      } catch (error) {
+        console.error('이벤트 목록 조회 실패:', error);
+      }
+    };
+    fetchEvents();
+  }, [currentPage, selectedCategory, selectedPeriod]);
 
   const handlePageChange = (page) => {
-    console.log(`Page changed to: ${page}`);
     setCurrentPage(page);
+  };
+
+  const handleFilterChange = (categoryLabel, periodLabel) => {
+    const mappedCategory = categoryMap[categoryLabel] || 'ALL';
+    const mappedPeriod = periodMap[periodLabel] || 'ALL';
+    setSelectedCategory(mappedCategory);
+    setSelectedPeriod(mappedPeriod);
+    setCurrentPage(1);
   };
 
   return (
     <div className={styles.page}>
-      <FilterBar />
+      <FilterBar onFilterChange={handleFilterChange} />
       <div className={styles.container}>
         <div className={styles.grid}>
-          {events.map((event) => (
-            <div key={event.id} onClick={() => navigate(`/events/${event.id}`)} style={{ cursor: 'pointer' }}>
+          {events.map((event, index) => (
+            <div key={event.id || index} onClick={() => navigate(`/events/${event.id}`)} style={{ cursor: 'pointer' }}>
               <EventCard event={event} />
             </div>
           ))}


### PR DESCRIPTION
## ✨ 새로운 기능 / 변경 사항
- 필터 클릭 시 즉시 이벤트 목록이 재조회되도록 로직 개선
- 사용자가 필터를 선택할 때마다 즉시 필터링된 이벤트 목록을 확인할 수 있음
- 불필요한 새로고침 없이 자연스러운 데이터 갱신

## 🛠 구현 상세
- 상태 관리: useState, useEffect를 사용하여 selectedCategory, selectedPeriod 변경 시마다 getEventList 호출
- 매핑 로직: 한글 라벨을 백엔드 Enum으로 매핑하는 categoryMap, periodMap 추가

## 🔧 추가 고려사항
- [ ] 백엔드 Enum(EventCategory, EventPeriod) 변경 시 프론트 categoryMap, periodMap 동기화 필요
- [ ] API 응답 구조(data.content, data.totalPages)가 변경될 경우 로직 수정 필요
- [ ] 필터 변경 시 기존 데이터 로딩 표시(스피너) 추가 고려

## 🔗 관련 문서 / 이슈
- Issue: #16 
