### PR TITLE
:recycle: Refactor: 키오스크 인사동 행사 리스트페이지 API 연동

### DIFF
--- a/src/api/eventList.js
+++ b/src/api/eventList.js
@@ -1,9 +1,10 @@
 import { APIService } from './axios';
 
-export const getEventList = async ({ eventCategory, eventPeriod, keyword, pageNum, pageSize }) => {
+export const getEventList = async ({ eventRegion, eventCategory, eventPeriod, keyword, pageNum, pageSize }) => {
   try {
-    const res = await APIService.public.get('/api/events', {
+    return await APIService.public.get('/api/events', {
       params: {
+        eventRegion,
         eventCategory,
         eventPeriod,
         keyword,
@@ -11,7 +12,6 @@ export const getEventList = async ({ eventCategory, eventPeriod, keyword, pageNu
         pageSize,
       },
     });
-    return res.data;
   } catch (err) {
     console.error('이벤트 페이지 조회 실패:', err);
     throw err;

--- a/src/components/eventListPage/FilterBar.jsx
+++ b/src/components/eventListPage/FilterBar.jsx
@@ -10,7 +10,7 @@ export default function FilterBar({
   onPrev,
   onNext,
 }) {
-  const categories = ['전체', '공연', '전시', '축제', '교육/강좌', '기타'];
+  const categories = ['전체', '공연', '전시', '기타'];
   const [selectedCategory, setSelectedCategory] = useState(selectedCategoryLabel);
 
   useEffect(() => setSelectedCategory(selectedCategoryLabel), [selectedCategoryLabel]);

--- a/src/components/global/header/KioskHeader.jsx
+++ b/src/components/global/header/KioskHeader.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { useNavigate, useLocation } from 'react-router-dom';
+import { useNavigate, useLocation, useSearchParams } from 'react-router-dom';
 import styles from './KioskHeader.module.css';
 
 import UnavailableModal from '@global/modal/UnavailableModal';
@@ -7,35 +7,41 @@ import UnavailableModal from '@global/modal/UnavailableModal';
 export default function KioskHeader({ active }) {
   const navigate = useNavigate();
   const { pathname } = useLocation();
+  const [searchParams, setSearchParams] = useSearchParams();
 
-  // 어떤 탭이 막혔는지 상태
-  const [blockedPage, setBlockedPage] = useState(null); // 'insadong' | 'promo' | null
+  const [blockedPage, setBlockedPage] = useState(null);
   const modalOpen = blockedPage !== null;
 
   const modalTitle = useMemo(() => {
-    if (blockedPage === 'insadong') return '인사동 페이지는 준비 중입니다';
     if (blockedPage === 'promo') return '프로모션 페이지는 준비 중입니다';
     return '';
   }, [blockedPage]);
 
+  const regionParam = searchParams.get('region') || 'jongno';
+
   const resolvedActive = useMemo(() => {
     if (active) return active;
     if (pathname.startsWith('/kiosk/mbti')) return 'mbti';
-    if (pathname.startsWith('/kiosk/events')) return 'jongno';
+    if (regionParam === 'insa') return 'insa';
     return 'jongno';
-  }, [active, pathname]);
+  }, [active, pathname, regionParam]);
 
-  // 모달 열리면 2초 후 종로구(/events)로 이동
   useEffect(() => {
     if (!modalOpen) return;
 
     const timer = setTimeout(() => {
       setBlockedPage(null);
-      navigate('/kiosk/events');
+      setSearchParams({ region: 'jongno' });
+      navigate('/kiosk/events?region=jongno');
     }, 2000);
 
     return () => clearTimeout(timer);
-  }, [modalOpen, navigate]);
+  }, [modalOpen, navigate, setSearchParams]);
+
+  const goRegion = (region) => {
+    setSearchParams({ region });
+    navigate(`/kiosk/events?region=${region}`);
+  };
 
   const go = (path) => {
     if (pathname !== path) navigate(path);
@@ -44,21 +50,22 @@ export default function KioskHeader({ active }) {
   return (
     <header className={styles.topHeader}>
       <nav className={styles.tabs}>
-        {/* 종로구 */}
         <button
           type='button'
           className={`${styles.tab} ${resolvedActive === 'jongno' ? styles.activeTab : ''}`}
-          onClick={() => go('/kiosk/events')}
+          onClick={() => goRegion('jongno')}
         >
           종로구
         </button>
 
-        {/* 인사동 (막힘) */}
-        <button type='button' className={styles.tab} onClick={() => setBlockedPage('insadong')}>
+        <button
+          type='button'
+          className={`${styles.tab} ${resolvedActive === 'insa' ? styles.activeTab : ''}`}
+          onClick={() => goRegion('insa')}
+        >
           인사동
         </button>
 
-        {/* MBTI */}
         <button
           type='button'
           className={`${styles.tab} ${resolvedActive === 'mbti' ? styles.activeTab : ''}`}
@@ -67,7 +74,6 @@ export default function KioskHeader({ active }) {
           MBTI
         </button>
 
-        {/* 프로모션 (막힘) */}
         <button type='button' className={styles.tab} onClick={() => setBlockedPage('promo')}>
           프로모션
         </button>
@@ -80,7 +86,8 @@ export default function KioskHeader({ active }) {
         onClose={() => setBlockedPage(null)}
         onConfirm={() => {
           setBlockedPage(null);
-          navigate('/kiosk/events');
+          setSearchParams({ region: 'jongno' });
+          navigate('/kiosk/events?region=jongno');
         }}
         width='40rem'
         height='20rem'

--- a/src/pages/KioskEventListPage.jsx
+++ b/src/pages/KioskEventListPage.jsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useEffect, useMemo, useState } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import styles from './KioskEventListPage.module.css';
 import KioskHeader from '@/components/global/header/KioskHeader';
 import KioskEventCard from '@/components/eventListPage/KioskEventCard';
@@ -12,6 +12,13 @@ import { getEventList } from '@/api/eventList';
 
 export default function KioskEventListPage() {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+
+  const regionParam = (searchParams.get('region') || 'jongno').toLowerCase();
+
+  const eventRegion = useMemo(() => {
+    return regionParam === 'insa' ? 'INSA' : 'JONGNO';
+  }, [regionParam]);
 
   const [page, setPage] = useState(1);
   const pageSize = 6;
@@ -28,12 +35,10 @@ export default function KioskEventListPage() {
     전체: 'ALL',
     공연: 'SHOW',
     전시: 'EXHIBITION',
-    축제: 'FESTIVAL',
-    '교육/강좌': 'EDUEXP',
     기타: 'ETC',
   };
 
-  const categories = ['전체', '공연', '전시', '축제', '교육/강좌', '기타'];
+  const categories = ['전체', '공연', '전시', '기타'];
 
   const handlePrevCategory = () => {
     const idx = categories.indexOf(categoryLabel);
@@ -53,6 +58,10 @@ export default function KioskEventListPage() {
   };
 
   useEffect(() => {
+    setPage(1);
+  }, [eventRegion]);
+
+  useEffect(() => {
     let mounted = true;
 
     (async () => {
@@ -61,6 +70,7 @@ export default function KioskEventListPage() {
         setErrorMsg('');
 
         const res = await getEventList({
+          eventRegion,
           eventCategory: categoryMap[categoryLabel] ?? 'ALL',
           pageNum: page,
           pageSize,
@@ -68,8 +78,7 @@ export default function KioskEventListPage() {
 
         if (!mounted) return;
 
-        const root = res?.data ? res.data : res;
-        const payload = root?.data ?? root ?? {};
+        const payload = res?.data ?? {};
         const nextEvents = Array.isArray(payload.content) ? payload.content : [];
 
         setEvents(nextEvents);
@@ -88,11 +97,11 @@ export default function KioskEventListPage() {
     return () => {
       mounted = false;
     };
-  }, [page, categoryLabel]);
+  }, [page, categoryLabel, eventRegion]);
 
   return (
     <div className={styles.page}>
-      <KioskHeader />
+      <KioskHeader active={eventRegion === 'INSA' ? 'insa' : 'jongno'} />
 
       <main className={styles.content}>
         <FilterBar

--- a/src/pages/KioskEventListPage.module.css
+++ b/src/pages/KioskEventListPage.module.css
@@ -47,6 +47,7 @@
 }
 
 .grid {
+  height: 1374px;
   margin-top: 60px;
   display: grid;
   grid-template-columns: repeat(3, 400px);
@@ -124,7 +125,7 @@
 }
 
 .emptyWrapper {
-  height: calc(2250px - 580px);
+  height: 1374px;
   display: flex;
   flex-direction: column;
   justify-content: center;


### PR DESCRIPTION
## ✨ 새로운 기능 / 변경 사항
- 종로구/인사동 지역 탭을 쿼리 파라미터(region) 기반으로 분리
- 전체/공연/전시/기타 카테고리 필터에 따른 이벤트 목록 API 연동


## 📱 테스트 방법

- [x] 브라우저에서 정상 동작 확인
- [x] 반응형 / 모바일 UI 확인

## 🔗 관련 문서 / 이슈

- Issue: #59 
